### PR TITLE
Fixed: double tab issue

### DIFF
--- a/lib/widgets/animated_listview.dart
+++ b/lib/widgets/animated_listview.dart
@@ -90,9 +90,12 @@ class _AnimatedListViewState extends State<AnimatedListView> {
 
         ///Set the animation duration to 0 after the transition in is finished.
         delayedAction(widget.animationDuration.inMilliseconds, () {
-          setState(() {
-            _animationDuration = const Duration(milliseconds: 0);
-          });
+          // To prevent setState() after state disposed
+          if (mounted) {
+            setState(() {
+              _animationDuration = const Duration(milliseconds: 0);
+            });
+          }
         });
       });
     });


### PR DESCRIPTION
Fixed issue: widget state throw exception when user double tap real  quick on dropdown while state is disposed